### PR TITLE
Add support for python 3

### DIFF
--- a/spidermonkey/__init__.py
+++ b/spidermonkey/__init__.py
@@ -3,6 +3,12 @@ import subprocess
 
 from pkg_resources import resource_filename
 
+# Python 3 support
+try:
+  basestring
+except NameError:
+  basestring = (str, bytes)
+
 
 __all__ = 'Spidermonkey',
 


### PR DESCRIPTION
There was only one change required to make this module work in python 3.5
basestring does not exist in python3, this adds a compatible tuple to replace it.